### PR TITLE
traefik metadata: 'docky.access.help' is replaced by 'docky.help'

### DIFF
--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-long.service=${COMPOSE_PROJECT_NAME}odoo_long"
       - "traefik.http.services.${COMPOSE_PROJECT_NAME}odoo.loadbalancer.server.port=8069"
       - "traefik.http.services.${COMPOSE_PROJECT_NAME}odoo_long.loadbalancer.server.port=8072"
-      - "docky.access.help=${COMPOSE_PROJECT_NAME}.localhost"
+      - "docky.help=${COMPOSE_PROJECT_NAME}.localhost"
     links:
       - db
     networks:


### PR DESCRIPTION
it seems we need to update the traefik metadata for traefik to work (after this I got it working with traefik v2.4., before no):

before:
```
rvalyi@rvalyi-laptop:~/DEV/docky14$ docky run
Going to remove docky14_db_1
Removing docky14_db_1 ... done
'docky.access.help' is replaced by 'docky.help'. Please update this key in your docker files.
Creating docky14_db_1 ... done
Creating docky14_odoo_run ... done
Starting with UID : 1000
Running with demo data
```

after:
```
rvalyi@rvalyi-laptop:~/DEV/docky14$ docky run
Going to remove docky14_db_1
Removing docky14_db_1 ... done
docky14.localhost
Creating docky14_db_1 ... done
Creating docky14_odoo_run ... done
Starting with UID : 1000
Running with demo data
```