### PR TITLE
fix yml indent

### DIFF
--- a/dev.docker-compose.yml
+++ b/dev.docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - "traefik.http.services.${COMPOSE_PROJECT_NAME}odoo.loadbalancer.server.port=8069"
       - "traefik.http.services.${COMPOSE_PROJECT_NAME}odoo_long.loadbalancer.server.port=8072"
       - "docky.help=${COMPOSE_PROJECT_NAME}.localhost"
-     volumes:
+    volumes:
       - ./odoo:/odoo
       - ./data/addons:/data/odoo/addons
       - ./data/filestore:/data/odoo/filestore


### PR DESCRIPTION
trivial fix. Otherwise you get errors such as:

```
  File "/usr/lib/python3/dist-packages/yaml/composer.py", line 84, in compose_node                                                                                                                           
    node = self.compose_mapping_node(anchor)                                                                                                                                                                 
  File "/usr/lib/python3/dist-packages/yaml/composer.py", line 133, in compose_mapping_node                                                                                                                  
    item_value = self.compose_node(node, item_key)                                                                                                                                                           
  File "/usr/lib/python3/dist-packages/yaml/composer.py", line 84, in compose_node                                                                                                                           
    node = self.compose_mapping_node(anchor)                                                                                                                                                                 
  File "/usr/lib/python3/dist-packages/yaml/composer.py", line 127, in compose_mapping_node                                                                                                                  
    while not self.check_event(MappingEndEvent):                                                                                                                                                             
  File "/usr/lib/python3/dist-packages/yaml/parser.py", line 98, in check_event                                                                                                                              
    self.current_event = self.state()                                                                                                                                                                        
  File "/usr/lib/python3/dist-packages/yaml/parser.py", line 438, in parse_block_mapping_key                                                                                                                 
    raise ParserError("while parsing a block mapping", self.marks[-1],                                                                                                                                       
yaml.parser.ParserError: while parsing a block mapping                                                                                                                                                       
  in "./dev.docker-compose.yml", line 18, column 5                                                                                                                                                           
expected <block end>, but found '<block mapping start>'                                                                                                                                                      
  in "./dev.docker-compose.yml", line 34, column 6      
```