### PR TITLE
Update db should just start/stop odoo and the entrypoint should run the right migration script

### DIFF
--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -129,7 +129,8 @@ update_db:
     - export PGDATABASE=$BUILD_NAME
     - echo "DB_NAME=$BUILD_NAME" >> .env
     - docker-compose kill
-    - docker-compose run odoo click-odoo-update
+    # Start and stop odoo, the entrypoint will run an update if needed
+    - docker-compose run odoo odoo --stop-after-init
   rules:
     # if emptydb tag is set this job will not run
     - if: $CI_MERGE_REQUEST_LABELS !~ /emptydb/


### PR DESCRIPTION
It's not need to explicitly run click-odoo-update as the entrypoint already do it.
So we just need to start/stop odoo and entrypoint do the work