### PR TITLE
[IMP] allow to build using private repos via ssh

### DIFF
--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -71,7 +71,9 @@ lint-optional:
 build:
   stage: build
   script:
-    - docker-compose build --pull
+    - eval "$(ssh-agent -s)"
+    - ssh-add ~/.ssh/id_ed25519
+    - docker compose build --pull --ssh default
 
 test:
   stage: test

--- a/src/odoo/.git_autoshare_repos.yml
+++ b/src/odoo/.git_autoshare_repos.yml
@@ -1,0 +1,13 @@
+github.com:
+  #  "my-private-repo":
+  #    orgs:
+  #      - akretion
+  #    private: True
+  "*":
+    orgs:
+      - odoo
+      - OCA
+      - acsone
+      - akretion
+      - camptocamp
+

--- a/src/odoo/Dockerfile.jinja
+++ b/src/odoo/Dockerfile.jinja
@@ -4,6 +4,12 @@ FROM ghcr.io/akretion/odoo-docker:{{ odoo_version }}-latest as base
 
 FROM base as prod
 
+# run keyscan for github (download public key) to not have to accept it manually
+RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+# Customize git autoshare repos config (and declare private repos)
+COPY ./.git_autoshare_repos.yaml /root/.config/git-autoshare/repos.yml
+
 # Build and install odoo
 COPY odoo-spec.yaml /odoo/odoo-spec.yaml
 ENV BUILD_RESTRICT_LANG=fr.po
@@ -13,7 +19,7 @@ RUN --mount=type=cache,target=/root/.cache pip install -e /odoo/src
 # Build external source
 COPY spec.yaml /odoo/spec.yaml
 COPY frozen.yaml /odoo/frozen.yaml
-RUN --mount=type=cache,target=/root/.cache /install/build-odoo-external
+RUN --mount=type=ssh --mount=type=cache,target=/root/.cache /install/build-odoo-external
 COPY ./requirements.txt /odoo/
 RUN --mount=type=cache,target=/root/.cache cd /odoo && pip install -r requirements.txt
 


### PR DESCRIPTION
This is not ready yet

We may want to put it behind `if`s to not activate it in every projects because it is not always useful.

This is inspired by this blog post:  https://medium.com/@tonistiigi/build-secrets-and-ssh-forwarding-in-docker-18-09-ae8161d066 

`docker compose` is needed to make it work (`sudo apt install docker-compose-plugin` on the build machine)