### PR TITLE
[FIX] Copy odoo config template file of the project in to the docker …

### DIFF
--- a/src/odoo/Dockerfile.jinja
+++ b/src/odoo/Dockerfile.jinja
@@ -17,6 +17,9 @@ RUN --mount=type=cache,target=/root/.cache /install/build-odoo-external
 COPY ./requirements.txt /odoo/
 RUN --mount=type=cache,target=/root/.cache cd /odoo && pip install -r requirements.txt
 
+# Copy odoo config template
+COPY ./templates /odoo/templates
+
 # Copy local project
 COPY ./start-entrypoint.d /odoo/start-entrypoint.d
 COPY ./local-src /odoo/local-src


### PR DESCRIPTION
…container

@hparfr @PierrickBrun @sebastienbeau 

With recent changes, we manage a template odoo config file, which is mounted in the dev.docker-compose but we need to copy it in the prod part of the Dockerfile to make it works for all environments