### PR TITLE
[FIX] update_oca_file

### DIFF
--- a/src/{% if odoo_version >= 14 %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/src/{% if odoo_version >= 14 %}.pre-commit-config.yaml{% endif %}.jinja
@@ -51,15 +51,7 @@
   {%- set repo_rev.setuptools_odoo = "3.1.8" %}
 {%- endif %}
 
-{#- Older versions that differ a lot have their own hardcoded templates for readability #}
-{%- if odoo_version < 13 %}
-  {%- include "version-specific/mqt-compat/.pre-commit-config.yaml.jinja" %}
 
-{%- elif odoo_version < 14 %}
-  {%- include "version-specific/%s/.pre-commit-config.yaml.jinja" % odoo_version %}
-
-{#- Newer versions without hacks are rendered here directly #}
-{%- else %}
 exclude: |
   (?x)
   # NOT INSTALLABLE ADDONS
@@ -189,4 +181,3 @@ repos:
       - id: pylint_odoo
         args:
           - --rcfile=.pylintrc-mandatory
-{%- endif %}

--- a/src/{% if odoo_version >= 14 %}.pylintrc-mandatory{% endif %}.jinja
+++ b/src/{% if odoo_version >= 14 %}.pylintrc-mandatory{% endif %}.jinja
@@ -1,6 +1,3 @@
-{%- if odoo_version < 13 %}
-  {%- include "version-specific/mqt-compat/.pylintrc-mandatory.jinja" %}
-{%- else %}
 [MASTER]
 load-plugins=pylint_odoo
 score=n
@@ -102,4 +99,3 @@ enable=anomalous-backslash-in-string,
 msg-template={path}:{line}: [{msg_id}({symbol}), {obj}] {msg}
 output-format=colorized
 reports=no
-{%- endif %}

--- a/src/{% if odoo_version >= 14 %}.pylintrc{% endif %}.jinja
+++ b/src/{% if odoo_version >= 14 %}.pylintrc{% endif %}.jinja
@@ -1,6 +1,3 @@
-{%- if odoo_version < 13 %}
-  {%- include "version-specific/mqt-compat/.pylintrc.jinja" %}
-{%- else %}
 {% extends "src/{% if odoo_version >= 14 %}.pylintrc-mandatory{% endif %}.jinja" %}
 {% block note %}
 # This .pylintrc contains optional AND mandatory checks and is meant to be
@@ -28,4 +25,3 @@
     too-complex,
     unnecessary-utf8-coding-comment
 {% endblock %}
-{%- endif %}


### PR DESCRIPTION
update_oca_file needed manual actions to fix it.

Now no manual action is needed.

I remove the references to the "version-specific" directory that is not copied here.

This created errors when trying to `copier update` from a project where odoo_version < 14