### PR TITLE
[FIX] stop_review dependent on artifacts

### DIFF
--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -188,6 +188,8 @@ stop_review:
     name: test/${BUILD_NAME}
     action: stop
   when: manual
+  # Do no require any artifact to run properly
+  dependencies: []
 
 # Send the docker image to the registry in order to be downloaded in prod
 docker_push:


### PR DESCRIPTION
by default, a job depends on all artifacts from precedent jobs.

stop_review can be run after some artifacts are deleted but that shouldn't prevent it to run