### PR TITLE
[FIX] Always launch tests on default branch

### DIFF
--- a/src/.gitlab-ci.yml.jinja
+++ b/src/.gitlab-ci.yml.jinja
@@ -106,6 +106,8 @@ test:
   rules:
     # Run tests in MR if there is no Skiptest tag
     - if: $IS_MR == "true" && $CI_MERGE_REQUEST_LABELS !~ /Skiptest/
+    # Always run test in default branch
+    - if: $IS_MR == null
   coverage: '/(?i)total.*? (100(?:\.0+)?\%|[1-9]?\d(?:\.\d+)?\%)$/'
   artifacts:
     reports:


### PR DESCRIPTION
I believe this was removed by mistake in https://github.com/akretion/docky-odoo-template/pull/73
Else, I think it deserves that we talk about that, should not the test be run on default branch, only un MR ?

I think it is importante because you could have 2 green MR that onced merged in main branch conflict and make test fails. (then you don't see it before making the next MR.)
I guess there may be other use cases... no ?

If it is decided that we don't launch test on default branch but only in MR, I can accept it, I just want it to be clear/discussed :)

