### PR TITLE
[FIX] Mount pytest config file in dev environment

### DIFF
--- a/src/dev.docker-compose.yml
+++ b/src/dev.docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - ./odoo/scripts:/odoo/scripts
       - ./odoo/requirements.txt:/odoo/requirements.txt
       - ./odoo/spec.yaml:/odoo/spec.yaml
+      - ./odoo/pytest.ini:/odoo/pytest.ini
       - ./data/addons:/data/odoo/addons
       - ./data/filestore:/data/odoo/filestore
       - ./data/sessions:/data/odoo/sessions


### PR DESCRIPTION
I guess this pytest config file became useless when we stopped mounting the whole odoo folder into the docker.