### PR TITLE
always install web_responsive by default

### DIFF
--- a/src/dev.docker-compose.yml
+++ b/src/dev.docker-compose.yml
@@ -29,6 +29,7 @@ services:
       WITHOUT_DEMO: "False"
       WORKERS: 0
       ODOO_REPORT_URL: http://odoo:8069
+      SERVER_WIDE_MODULES: base,web,web_responsive
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=traefik"


### PR DESCRIPTION
this way web_responsive is always installed when you create a dev database and you feel better.