### PR TITLE
save the planet 1/2: don't copy odoo/src in every dev images, it's already mounted!

### DIFF
--- a/src/odoo/Dockerfile.jinja
+++ b/src/odoo/Dockerfile.jinja
@@ -27,7 +27,13 @@ COPY ./scripts /odoo/scripts
 
 FROM base as dev
 
-COPY ./src /odoo/src
+# the following copy just enough metadata to get pip install -e /odoo/src to run:
+COPY ./src/requirements.txt /odoo/src/requirements.txt
+COPY ./src/setup.cfg /odoo/src/setup.cfg
+COPY ./src/setup.py /odoo/src/setup.py
+COPY ./src/setup /odoo/src/setup
+COPY ./src/odoo/release.py /odoo/src/odoo/release.py
+
 RUN --mount=type=cache,target=/root/.cache pip install -e /odoo/src
 COPY ./requirements.txt /odoo/
 RUN --mount=type=cache,target=/root/.cache pip install -r /odoo/requirements.txt


### PR DESCRIPTION
back in the early Docky versions we were doing it right and more recently somebody screwed it. Basically /odoo/src will already be a mounted volume when running Docky (docky run) so Odoo source code will be be available as expected.

The only things we need is just enough of Odoo metadata to get the next pip install lines to run:
```
RUN --mount=type=cache,target=/root/.cache pip install -e /odoo/src
COPY ./requirements.txt /odoo/
RUN --mount=type=cache,target=/root/.cache pip install -r /odoo/requirements.txt
```

And this is exactly the just enough files I copied in the 5 lines before in this PR!

You can test with docker build it locally. In the best case before you were copying around 250 Mb of Odoo files if you were a git-autoshare ninja and had just an odoo shallow clone in your odoo/src. But I guess many of us, in fact had full blown odoo clones in odoo/src (because otherwise without git-autoshare you cannot merge a damn Odoo pull request). That is people had around 5.7 Gb of useless odoo git files in every project they were working on locally. 6 or 7 active projects you you easily kill an SSD for nothing!


cc @sebastienbeau @PierrickBrun @hparfr @bealdav @renatonlima @mbcosta 