### PR TITLE
[FIX] SENTRY value in prod.docker-compose

### DIFF
--- a/src/prod.docker-compose.yml
+++ b/src/prod.docker-compose.yml
@@ -19,7 +19,7 @@ services:
       ODOO_BASE_URL: TODO
       PGSSLMODE: require
       RUNNING_ENV: prod
-      SENTRY: True
+      SENTRY: "True"
     volumes:
       - ~/data/${COMPOSE_PROJECT_NAME}/addons:/data/odoo/addons
       - ~/data/${COMPOSE_PROJECT_NAME}/filestore:/data/odoo/filestore


### PR DESCRIPTION
l semblerait que le format actuel ne soit pas correct pour docker-compose.
En tout cas, ça plante chez moi et on uniformise pour faire comme ici par exemple : https://github.com/akretion/docky-odoo-template/blob/main/src/docker-compose.yml#L31

@hparfr @Kev-Roche