### PR TITLE
[FIX] Exclude frozen.yaml from pre-commit because it is generated automatically

### DIFF
--- a/src/{% if odoo_version >= 14 %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/src/{% if odoo_version >= 14 %}.pre-commit-config.yaml{% endif %}.jinja
@@ -67,7 +67,9 @@ exclude: |
   # Repos using Sphinx to generate docs don't need prettying
   ^docs/_templates/.*\.html$|
   # You don't usually want a bot to modify your legal texts
-  (LICENSE.*|COPYING.*)
+  (LICENSE.*|COPYING.*)|
+  # Avoid frozen which is auto-generated
+  /frozen.yaml
 default_language_version:
   python: python3
   node: "{{ repo_rev.nodejs }}"


### PR DESCRIPTION
If  we delete it and re-create it, it is full of unwanted diff because of pre-commit reformat

@bealdav @Kev-Roche @sebastienbeau @hparfr 