### PR TITLE
[FIX] .env-sample docker compose file order

### DIFF
--- a/src/.env-sample.jinja
+++ b/src/.env-sample.jinja
@@ -1,5 +1,5 @@
 UID=1000
-COMPOSE_FILE=dev.docker-compose.yml:docker-compose.yml{% if provide_adminer %}:.adminer.dc.yml{% endif %}{% if provide_web_debugger %}:.wdb.dc.yml{% endif %}
+COMPOSE_FILE=docker-compose.yml:dev.docker-compose.yml{% if provide_adminer %}:.adminer.dc.yml{% endif %}{% if provide_web_debugger %}:.wdb.dc.yml{% endif %}
 COMPOSE_PROJECT_NAME={{project_name}}
 COMPOSE_DOCKER_CLI_BUILD=1
 ENV=dev


### PR DESCRIPTION
@Kev-Roche @hparfr @sebastienbeau 

I believe the dev.docker-compose.yml must figure after the docker-compose.yml in the `.env` file for proper inheritance.